### PR TITLE
Removed default configuration included in GWiz Batcher.

### DIFF
--- a/gwiz-batcher.php
+++ b/gwiz-batcher.php
@@ -18,27 +18,27 @@ function gwiz_batcher() {
 
 	require_once( plugin_dir_path( __FILE__ ) . 'class-gwiz-batcher.php' );
 
-	new Gwiz_Batcher( array(
-		'title'        => 'GW Batcher',
-		'id'           => 'gw-batcher',
-		'size'         => 25,
-		'get_items'    => function ( $size, $offset ) {
-
-			$paging  = array(
-				'offset'    => $offset,
-				'page_size' => $size,
-			);
-
-			$entries = GFAPI::get_entries( null, array(), null, $paging, $total );
-
-			return array(
-				'items' => $entries,
-				'total' => $total,
-			);
-		},
-		'process_item' => function ( $entry ) {
-			// Process the item here.
-		},
-	) );
-
+	// Example configuration
+	//  new Gwiz_Batcher( array(
+	//      'title'        => 'GW Batcher',
+	//      'id'           => 'gw-batcher',
+	//      'size'         => 25,
+	//      'get_items'    => function ( $size, $offset ) {
+	//
+	//          $paging  = array(
+	//              'offset'    => $offset,
+	//              'page_size' => $size,
+	//          );
+	//
+	//          $entries = GFAPI::get_entries( null, array(), null, $paging, $total );
+	//
+	//          return array(
+	//              'items' => $entries,
+	//              'total' => $total,
+	//          );
+	//      },
+	//      'process_item' => function ( $entry ) {
+	//          // Process the item here.
+	//      },
+	//  ) );
 }


### PR DESCRIPTION
This PR removes the default configuration in Gwiz Batcher and leaves it up to be implemented via a snippet.

This will allow end users to customize Gwiz Batcher as needed vs having to modify core.

[Snippet sample](https://gist.github.com/eihabi/9bd0020d32defd4dd28120e17514be0b).
Ticket: [#24791](https://secure.helpscout.net/conversation/1525272327/24791/)